### PR TITLE
Add a functional test where case class constructor becomes private

### DIFF
--- a/reporter/functional-tests/src/test/case-class-constructor-becomes-private-ok/v1/A.scala
+++ b/reporter/functional-tests/src/test/case-class-constructor-becomes-private-ok/v1/A.scala
@@ -1,0 +1,1 @@
+case class A()

--- a/reporter/functional-tests/src/test/case-class-constructor-becomes-private-ok/v2/A.scala
+++ b/reporter/functional-tests/src/test/case-class-constructor-becomes-private-ok/v2/A.scala
@@ -1,0 +1,1 @@
+case class A private ()


### PR DESCRIPTION
Noticed this in the wild. This change is not source compatible but is binary compatible.