### PR TITLE
Add setup for testing Scala 2.11 on CI!

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -19,21 +19,25 @@ matrix:
 
 env:
   matrix:
-    - TEST_COMMAND="mimaReportBinaryIssues test it:test"
+    - TEST_COMMAND="-Dmima.buildScalaVersion=2.10.7 mimaReportBinaryIssues test it:test"
     - TEST_COMMAND="-Dmima.buildScalaVersion=2.12.7 ^^1.1.5 mimaReportBinaryIssues test it:test"
     - TEST_COMMAND="-Dmima.buildScalaVersion=2.13.0-M5 core/test reporter/test reporter-functional-tests/test it:test"
-    - TEST_COMMAND="testFunctional"
-    - TEST_COMMAND="-Dmima.testScalaVersion=2.11.12 testFunctional"
-    - TEST_COMMAND="-Dmima.testScalaVersion=2.12.7 testFunctional"
-    - TEST_COMMAND="-Dmima.testScalaVersion=2.13.0-M5 testFunctional"
+
+    - TEST_COMMAND="-Dmima.buildScalaVersion=2.10.7 testFunctional"
+    - TEST_COMMAND="-Dmima.buildScalaVersion=2.10.7 -Dmima.testScalaVersion=2.11.12 testFunctional"
+    - TEST_COMMAND="-Dmima.buildScalaVersion=2.10.7 -Dmima.testScalaVersion=2.12.7 testFunctional"
+    - TEST_COMMAND="-Dmima.buildScalaVersion=2.10.7 -Dmima.testScalaVersion=2.13.0-M5 testFunctional"
+
     - TEST_COMMAND="-Dmima.buildScalaVersion=2.12.7 testFunctional"
     - TEST_COMMAND="-Dmima.buildScalaVersion=2.12.7 -Dmima.testScalaVersion=2.11.12 testFunctional"
     - TEST_COMMAND="-Dmima.buildScalaVersion=2.12.7 -Dmima.testScalaVersion=2.12.7 testFunctional"
     - TEST_COMMAND="-Dmima.buildScalaVersion=2.12.7 -Dmima.testScalaVersion=2.13.0-M5 testFunctional"
+
     - TEST_COMMAND="-Dmima.buildScalaVersion=2.13.0-M5 testFunctional"
     - TEST_COMMAND="-Dmima.buildScalaVersion=2.13.0-M5 -Dmima.testScalaVersion=2.11.12 testFunctional"
     - TEST_COMMAND="-Dmima.buildScalaVersion=2.13.0-M5 -Dmima.testScalaVersion=2.12.7 testFunctional"
     - TEST_COMMAND="-Dmima.buildScalaVersion=2.13.0-M5 -Dmima.testScalaVersion=2.13.0-M5 testFunctional"
+
     - TEST_COMMAND="scripted"
     - TEST_COMMAND="-Dmima.buildScalaVersion=2.12.7 ^^1.1.5 scripted"
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -20,6 +20,7 @@ matrix:
 env:
   matrix:
     - TEST_COMMAND="-Dmima.buildScalaVersion=2.10.7 mimaReportBinaryIssues test it:test"
+    - TEST_COMMAND="-Dmima.buildScalaVersion=2.11.12 mimaReportBinaryIssues core/test reporter/test reporter-functional-test/test it:test"
     - TEST_COMMAND="-Dmima.buildScalaVersion=2.12.7 ^^1.1.5 mimaReportBinaryIssues test it:test"
     - TEST_COMMAND="-Dmima.buildScalaVersion=2.13.0-M5 core/test reporter/test reporter-functional-tests/test it:test"
 
@@ -27,6 +28,10 @@ env:
     - TEST_COMMAND="-Dmima.buildScalaVersion=2.10.7 -Dmima.testScalaVersion=2.11.12 testFunctional"
     - TEST_COMMAND="-Dmima.buildScalaVersion=2.10.7 -Dmima.testScalaVersion=2.12.7 testFunctional"
     - TEST_COMMAND="-Dmima.buildScalaVersion=2.10.7 -Dmima.testScalaVersion=2.13.0-M5 testFunctional"
+
+    - TEST_COMMAND="-Dmima.buildScalaVersion=2.11.12 -Dmima.testScalaVersion=2.11.12 testFunctional"
+    - TEST_COMMAND="-Dmima.buildScalaVersion=2.11.12 -Dmima.testScalaVersion=2.12.7 testFunctional"
+    - TEST_COMMAND="-Dmima.buildScalaVersion=2.11.12 -Dmima.testScalaVersion=2.13.0-M5 testFunctional"
 
     - TEST_COMMAND="-Dmima.buildScalaVersion=2.12.7 testFunctional"
     - TEST_COMMAND="-Dmima.buildScalaVersion=2.12.7 -Dmima.testScalaVersion=2.11.12 testFunctional"


### PR DESCRIPTION
Also add the implicit buildScalaVersion in .travis.yml and break the build matrix up into sections.