### PR TITLE
Fix NoClass, use NoPackageInfo over null

### DIFF
--- a/core/src/main/scala/com/typesafe/tools/mima/core/ClassInfo.scala
+++ b/core/src/main/scala/com/typesafe/tools/mima/core/ClassInfo.scala
@@ -25,7 +25,7 @@ class SyntheticClassInfo(owner: PackageInfo, override val bytecodeName: String) 
 }
 
 /** As the name implies. */
-object NoClass extends SyntheticClassInfo(null, "<noclass>") {
+object NoClass extends SyntheticClassInfo(NoPackageInfo, "<noclass>") {
   override def canEqual(other: Any) = other.isInstanceOf[NoClass.type]
   override lazy val superClasses = Set.empty[ClassInfo]
 }

--- a/core/src/test/scala/com/typesafe/tools/mima/core/ProblemReportingSpec.scala
+++ b/core/src/test/scala/com/typesafe/tools/mima/core/ProblemReportingSpec.scala
@@ -41,9 +41,9 @@ class ProblemReportingSpec extends WordSpec with Matchers {
   }
 
   private def isReported(moduleVersion: String, filters: Seq[ProblemFilter]) =
-    ProblemReporting.isReported(moduleVersion, filters, Map.empty)(NoOpLogger, "test", "current")(FinalClassProblem(SafeNoClass))
+    ProblemReporting.isReported(moduleVersion, filters, Map.empty)(NoOpLogger, "test", "current")(FinalClassProblem(NoClass))
   private def isReported(moduleVersion: String, versionedFilters: Map[String, Seq[ProblemFilter]]) =
-    ProblemReporting.isReported(moduleVersion, Seq.empty, versionedFilters)(NoOpLogger, "test", "current")(FinalClassProblem(SafeNoClass))
+    ProblemReporting.isReported(moduleVersion, Seq.empty, versionedFilters)(NoOpLogger, "test", "current")(FinalClassProblem(NoClass))
 
 }
 
@@ -53,11 +53,6 @@ object ProblemReportingSpec {
     override def debugLog(str: String): Unit = ()
     override def warn(str: String): Unit = ()
     override def error(str: String): Unit = ()
-  }
-
-  object SafeNoClass extends SyntheticClassInfo(NoPackageInfo, "<noclass>") {
-    override def canEqual(other: Any) = other.isInstanceOf[NoClass.type]
-    override lazy val superClasses = Set.empty[ClassInfo]
   }
 
   final val AllMatchingFilter = (_: Problem) => false


### PR DESCRIPTION
This removes a use of null, and makes NoClass not fall over so easily,
such as in ProblemReportingSpec, where I can switch to using it.