### PR TITLE
Make mimaReportBinaryIssues fail

### DIFF
--- a/sbtplugin/src/main/scala/com/typesafe/tools/mima/plugin/Keys.scala
+++ b/sbtplugin/src/main/scala/com/typesafe/tools/mima/plugin/Keys.scala
@@ -8,6 +8,7 @@ object MimaKeys extends BaseMimaKeys
 class BaseMimaKeys {
 
   final val mimaFailOnProblem      = settingKey[Boolean]("if true, fail the build on binary incompatibility detection.")
+  final val mimaFailOnNoPrevious   = settingKey[Boolean]("if true, fail the build if no previous artifacts are set.")
   final val mimaPreviousArtifacts  = settingKey[Set[ModuleID]]("Previous released artifacts used to test binary compatibility.")
   final val mimaPreviousClassfiles = taskKey[Map[ModuleID, File]]("Directories or jars containing the previous class files used to test compatibility with a given module.")
   final val mimaCurrentClassfiles  = taskKey[File]("Directory or jar containing the current class files used to test compatibility.")

--- a/sbtplugin/src/main/scala/com/typesafe/tools/mima/plugin/MimaPlugin.scala
+++ b/sbtplugin/src/main/scala/com/typesafe/tools/mima/plugin/MimaPlugin.scala
@@ -88,14 +88,9 @@ object MimaPlugin extends AutoPlugin {
       val ivy = ivySbt.value
       val taskStreams = streams.value
 
-      mimaPreviousArtifacts.value.map{ m =>
-        // TODO - These should be better handled in sbt itself.
-        // The cross version API is horribly intricately odd.
-        CrossVersion(m, scalaModuleInfoV) match {
-          case Some(f) => m withName f(m.name)
-          case None => m
-        }
-      }.map{ id =>
+      mimaPreviousArtifacts.value.iterator.map { m =>
+        val nameMod = CrossVersion(m, scalaModuleInfoV).getOrElse(idFun)
+        val id = m.withName(nameMod(m.name))
         id -> SbtMima.getPreviousArtifact(id, ivy, taskStreams)
       }.toMap
     },


### PR DESCRIPTION
One can resolve this issue by:

    * setting mimaPreviousArtifacts,
   * setting `mimaFailOnNoPrevious := false`, or
   * setting `mimaFailOnNoPrevious in ThisBuild := false`

Also by disabling MimaPlugin, but maybe that's a bit heavy-handed.

Also, cleanup and dedup some.

Fixes #263