### PR TITLE
Remove redundant testFunctional calls

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -20,7 +20,6 @@ matrix:
 env:
   matrix:
     - TEST_COMMAND="sbt -Dmima.buildScalaVersion=2.12.7 mimaReportBinaryIssues test it:test"
-    - TEST_COMMAND="sbt -Dmima.buildScalaVersion=2.12.7 testFunctional"
     - TEST_COMMAND="sbt -Dmima.buildScalaVersion=2.12.7 -Dmima.testScalaVersion=2.11.12 testFunctional"
     - TEST_COMMAND="sbt -Dmima.buildScalaVersion=2.12.7 -Dmima.testScalaVersion=2.12.7 testFunctional"
     - TEST_COMMAND="sbt -Dmima.buildScalaVersion=2.12.7 -Dmima.testScalaVersion=2.13.0-M5 testFunctional"
@@ -28,7 +27,6 @@ env:
     - TEST_COMMAND="sbt -Dmima.buildScalaVersion=2.12.7 \"scripted sbt-mima-plugin/*2of2\""
 
     - TEST_COMMAND="sbt -Dmima.buildScalaVersion=2.13.0-M5 core/test reporter/test reporter-functional-tests/test it:test"
-    - TEST_COMMAND="sbt -Dmima.buildScalaVersion=2.13.0-M5 testFunctional"
     - TEST_COMMAND="sbt -Dmima.buildScalaVersion=2.13.0-M5 -Dmima.testScalaVersion=2.11.12 testFunctional"
     - TEST_COMMAND="sbt -Dmima.buildScalaVersion=2.13.0-M5 -Dmima.testScalaVersion=2.12.7 testFunctional"
     - TEST_COMMAND="sbt -Dmima.buildScalaVersion=2.13.0-M5 -Dmima.testScalaVersion=2.13.0-M5 testFunctional"


### PR DESCRIPTION
These are equivalent to:
- TEST_COMMAND="sbt -Dmima.buildScalaVersion=2.12.7 -Dmima.testScalaVersion=2.12.7 testFunctional"
- TEST_COMMAND="sbt -Dmima.buildScalaVersion=2.13.0-M5 -Dmima.testScalaVersion=2.13.0-M5 testFunctional"

and are leftovers from when the build would default to scala version 2.10